### PR TITLE
fix: Prevent dashboard crash on API failure

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -6,9 +6,22 @@ export default async function Page() {
         getSSIDInfo(),
         getCustomerInfo()
     ]);
+
+    if (!ssidInfo) {
+        return (
+            <div className="w-full min-h-[100dvh] flex items-center justify-center p-4">
+                <div className="alert alert-error max-w-lg">
+                    <span>
+                        Error: Could not retrieve device information. Please ensure your environment configuration (e.g., GENIEACS_URL) is correct and try again later.
+                    </span>
+                </div>
+            </div>
+        );
+    }
+
     return (
         <div className="w-full min-h-[100dvh]">
-            <ClientView ssidInfo={ssidInfo!} customerInfo={customerInfo}/>
+            <ClientView ssidInfo={ssidInfo} customerInfo={customerInfo}/>
         </div>
     );
 }


### PR DESCRIPTION
This commit adds a null check for the `ssidInfo` object in the dashboard page.

Previously, if the `getSSIDInfo` API call failed and returned null, the page would attempt to access properties on a null object, causing the application to crash.

This change ensures that if `ssidInfo` is null, a user-friendly error message is displayed instead of rendering the main component, thus preventing the crash and improving application robustness.