### PR TITLE
fix: Correct login redirect handling

### DIFF
--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -33,16 +33,17 @@ export default function Login() {
         setLoading(true);
         setAlertMessage('');
         const result = await signIn('credentials', {
-            redirect: false, // Set to false to handle redirect manually
+            callbackUrl: '/dashboard',
+            redirect: true,
             phoneNumber: phoneNumber!.slice(1),
             otp,
         });
+
+        // This code now only runs if the redirect fails, i.e., an error occurred.
         if (result?.error) {
-            setAlertMessage('Invalid OTP or failed to sign in');
-        } else if (result?.ok) {
-            router.push('/dashboard');
+            setAlertMessage('Invalid OTP or failed to sign in. Please try again.');
+            setLoading(false);
         }
-        setLoading(false);
     };
 
     return (


### PR DESCRIPTION
This commit fixes a bug where you would get stuck in a loading state on the login page after submitting a valid OTP.

The issue was caused by setting `redirect: false` in the `signIn` call, which prevented NextAuth's default redirect mechanism from firing correctly.

The fix reverts to the standard NextAuth pattern by removing the `redirect: false` option and allowing NextAuth to handle the redirect automatically. This ensures a successful login correctly navigates you to the dashboard.