### PR TITLE
fix: Remove unused variable to resolve ESLint error

### DIFF
--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -2,13 +2,11 @@
 import React, { useState } from 'react';
 import { signIn } from 'next-auth/react';
 import { requestOtp } from '@/utils/auth.server';
-import { useRouter } from 'next/navigation';
 import 'react-phone-number-input/style.css'
 import PhoneInput from 'react-phone-number-input'
 import { Phone, KeyRound, ArrowRight } from 'lucide-react'; // Import icons
 
 export default function Login() {
-    const router = useRouter();
     const [phoneNumber, setPhoneNumber] = useState<string | undefined>();
     const [otp, setOtp] = useState('');
     const [otpRequested, setOtpRequested] = useState(false);


### PR DESCRIPTION
This commit removes the unused `useRouter` import and the `router` variable declaration from the login page component.

This unused code was causing an ESLint error (`@typescript-eslint/no-unused-vars`) which was configured to fail the production build (`next build`). Removing it resolves the build failure.