### PR TITLE
fix: Correctly type chart tooltip component

### DIFF
--- a/src/app/dashboard/charts.view.tsx
+++ b/src/app/dashboard/charts.view.tsx
@@ -3,11 +3,15 @@
 import type { SSIDInfo } from "./actions";
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
 
-import { TooltipProps } from 'recharts';
-import { ValueType, NameType } from 'recharts/types/component/DefaultTooltipContent';
+// Define a specific interface for the tooltip props
+interface CustomTooltipProps {
+    active?: boolean;
+    payload?: { value: number }[];
+    label?: string;
+}
 
-// Custom Tooltip for better styling
-const CustomTooltip = ({ active, payload, label }: TooltipProps<ValueType, NameType>) => {
+// Custom Tooltip for better styling, now with a correct and specific type
+const CustomTooltip = ({ active, payload, label }: CustomTooltipProps) => {
     if (active && payload && payload.length) {
         return (
             <div className="p-2 bg-black/50 backdrop-blur-sm border border-white/20 rounded-md text-white">


### PR DESCRIPTION
This commit fixes a TypeScript error in the `charts.view.tsx` component that was causing the build to fail.

The `CustomTooltip` component's props were previously typed incorrectly, leading to a type error (`Property 'payload' does not exist...`).

This has been resolved by defining a specific local interface (`CustomTooltipProps`) for the component's props. This ensures type safety, removes the TypeScript error, and allows the project to build successfully.