### PR TITLE
fix: Correct import path in wifi view component

### DIFF
--- a/src/app/dashboard/wifi/view.tsx
+++ b/src/app/dashboard/wifi/view.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useState } from "react";
-import type { SSIDInfo } from "../../actions";
-import Form from "../../client.form"; // Re-using the existing form component
+import type { SSIDInfo } from "../actions";
+import Form from "../client.form"; // Re-using the existing form component
 import { Wifi, ChevronDown } from 'lucide-react';
 
 const allowSsid = ["1", "5"];


### PR DESCRIPTION
This commit fixes a "Module not found" build error in the `wifi/view.tsx` component.

The error was caused by an incorrect relative import path for the `Form` component after refactoring the dashboard into a multi-page layout. The path has been corrected from `../../client.form` to `../client.form`.