### PR TITLE
fix: Remove unused variable in wifi view component

### DIFF
--- a/src/app/dashboard/wifi/view.tsx
+++ b/src/app/dashboard/wifi/view.tsx
@@ -8,7 +8,7 @@ import { Wifi, ChevronDown } from 'lucide-react';
 const allowSsid = ["1", "5"];
 
 export default function WifiView({ ssidInfo: initialSsidInfo }: { ssidInfo: SSIDInfo }) {
-    const [ssidInfo, setSSIDInfo] = useState<SSIDInfo>(initialSsidInfo);
+    const [ssidInfo] = useState<SSIDInfo>(initialSsidInfo);
     const [selectedSSID, setSelectedSSID] = useState<string>(ssidInfo.ssid[0].id);
     const [syncedSsids, setSyncedSsids] = useState<string[]>(allowSsid);
 


### PR DESCRIPTION
This commit fixes an ESLint build error (`no-unused-vars`) in the `wifi/view.tsx` component.

The `setSSIDInfo` variable was declared but never used after the component was refactored. This has been removed to resolve the build failure.