### PR TITLE
fix: Correct data format for report submission

### DIFF
--- a/src/app/dashboard/actions.ts
+++ b/src/app/dashboard/actions.ts
@@ -198,7 +198,8 @@ export async function submitReport(prevState: { message: string, success: boolea
     const report = {
       phoneNumber: session.user.id,
       name: customerInfo.name,
-      reportText: `${formData.get('category')}: ${formData.get('description')}`
+      category: formData.get('category'),
+      reportText: formData.get('description')
     };
 
     try {


### PR DESCRIPTION
This commit fixes an issue where submitted reports were not being saved to the database because the frontend was sending a data structure that did not match the backend's expectation.

The `submitReport` server action has been updated to send `category` and `reportText` as separate fields in the JSON payload, rather than combining them. This aligns with the API specification and ensures the backend can process the report correctly.