### PR TITLE
feat: Add status overview and report history page

### DIFF
--- a/src/app/dashboard/actions.ts
+++ b/src/app/dashboard/actions.ts
@@ -32,6 +32,25 @@ interface CustomerInfo {
     address: string;
 }
 
+export interface ReportHistoryItem {
+    id: string;
+    category: string;
+    status: 'Submitted' | 'In Progress' | 'Resolved';
+    submittedAt: string;
+}
+
+export interface DashboardStatus {
+    activeBoost: {
+        profile: string;
+        expiresAt: string;
+    } | null;
+    activeReport: {
+        id: string;
+        category: string;
+        status: 'Submitted' | 'In Progress';
+    } | null;
+}
+
 export interface BoostPackage {
     name: string;
     price: string;
@@ -251,7 +270,37 @@ export type {
     SSID,
     SSIDInfo,
     AssociatedDevice,
-    CustomerInfo
+    CustomerInfo,
+    BoostPackage,
+    ReportHistoryItem,
+    DashboardStatus
+}
+
+export async function getDashboardStatus(): Promise<DashboardStatus> {
+    // Placeholder: Replace with actual API call to GET /api/dashboard-status
+    console.log("Fetching dashboard status (placeholder)...");
+    // Simulate a mix of states for testing
+    return {
+        activeBoost: {
+            profile: '12Mbps',
+            expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+        },
+        activeReport: {
+            id: 'report-123',
+            category: 'Slow Connection',
+            status: 'In Progress',
+        }
+    };
+}
+
+export async function getReportHistory(): Promise<ReportHistoryItem[]> {
+    // Placeholder: Replace with actual API call to GET /api/reports/history
+    console.log("Fetching report history (placeholder)...");
+    return [
+        { id: 'RPT-001', category: 'Slow Connection', status: 'Resolved', submittedAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString() },
+        { id: 'RPT-002', category: 'No Connection', status: 'Resolved', submittedAt: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString() },
+        { id: 'RPT-003', category: 'Other', status: 'Submitted', submittedAt: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString() },
+    ];
 }
 
 export async function requestSpeedBoost(targetPackageName: string, duration: string) {

--- a/src/app/dashboard/bottom.nav.tsx
+++ b/src/app/dashboard/bottom.nav.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { LayoutDashboard, Wifi, MessageSquareWarning, Rocket } from 'lucide-react';
+import { LayoutDashboard, Wifi, MessageSquareWarning, Rocket, History } from 'lucide-react';
 
 // This is a placeholder for the modal trigger function that will be passed as a prop.
 type BottomNavProps = {
@@ -16,11 +16,12 @@ export default function BottomNav({ onReportClick }: BottomNavProps) {
         { href: '/dashboard', label: 'Dashboard', icon: LayoutDashboard },
         { href: '/dashboard/wifi', label: 'Wi-Fi', icon: Wifi },
         { href: '/dashboard/speed-boost', label: 'Boost', icon: Rocket },
+        { href: '/dashboard/history', label: 'History', icon: History },
     ];
 
     return (
         <div className="fixed bottom-0 left-0 z-50 w-full h-16 bg-white/10 backdrop-blur-lg border-t border-white/20">
-            <div className="grid h-full max-w-lg grid-cols-4 mx-auto font-medium">
+            <div className="grid h-full max-w-lg grid-cols-5 mx-auto font-medium">
                 {navItems.map((item) => {
                     const isActive = pathname === item.href;
                     return (

--- a/src/app/dashboard/client.view.tsx
+++ b/src/app/dashboard/client.view.tsx
@@ -6,9 +6,11 @@ import { getSSIDInfo, rebootRouter, refreshObject } from "./actions";
 
 import CustomerView from "./customer.view";
 import SignalStrengthIcon from "./SignalStrengthIcon";
+import StatusView from "./status.view";
 import { Power, RefreshCw, Check, X, Users } from 'lucide-react';
+import { DashboardStatus } from "../actions";
 
-export default function View({ ssidInfo: initialSsidInfo, customerInfo }: { ssidInfo: SSIDInfo, customerInfo: CustomerInfo | null }) {
+export default function View({ ssidInfo: initialSsidInfo, customerInfo, dashboardStatus }: { ssidInfo: SSIDInfo, customerInfo: CustomerInfo | null, dashboardStatus: DashboardStatus }) {
     const [ssidInfo, setSSIDInfo] = useState<SSIDInfo>(initialSsidInfo);
     const [loading, setLoading] = useState<boolean>(false);
     const [modalState, setModalState] = useState<{ action: 'reboot' | 'logout', description: string, text: string } | null>(null);
@@ -88,6 +90,8 @@ export default function View({ ssidInfo: initialSsidInfo, customerInfo }: { ssid
             </dialog>
 
             <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
+
+                <StatusView status={dashboardStatus} />
 
                 {/* Customer Info Card */}
                 <div className="xl:col-span-1">

--- a/src/app/dashboard/history/page.tsx
+++ b/src/app/dashboard/history/page.tsx
@@ -1,0 +1,10 @@
+import { getReportHistory } from "../actions";
+import HistoryView from "./view";
+
+export const dynamic = 'force-dynamic';
+
+export default async function HistoryPage() {
+    const history = await getReportHistory();
+
+    return <HistoryView history={history} />;
+}

--- a/src/app/dashboard/history/view.tsx
+++ b/src/app/dashboard/history/view.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import type { ReportHistoryItem } from "../actions";
+import { History } from 'lucide-react';
+
+const StatusBadge = ({ status }: { status: ReportHistoryItem['status'] }) => {
+    const statusClasses = {
+        Submitted: 'badge-info',
+        'In Progress': 'badge-warning',
+        Resolved: 'badge-success',
+    };
+    return <div className={`badge ${statusClasses[status]} text-white`}>{status}</div>;
+};
+
+export default function HistoryView({ history }: { history: ReportHistoryItem[] }) {
+    return (
+        <div>
+            <h1 className="text-3xl font-bold text-white mb-6 flex items-center"><History className="mr-3"/>Report History</h1>
+
+            {history.length > 0 ? (
+                <div className="space-y-4">
+                    {history.map((item) => (
+                        <div key={item.id} className="card bg-white/10 border border-white/20 shadow-lg">
+                            <div className="card-body">
+                                <div className="flex justify-between items-start">
+                                    <div>
+                                        <h2 className="card-title text-white">{item.category}</h2>
+                                        <p className="text-sm text-gray-400">Reported on: {new Date(item.submittedAt).toLocaleDateString()}</p>
+                                    </div>
+                                    <StatusBadge status={item.status} />
+                                </div>
+                                <p className="text-gray-300 mt-2">Report ID: {item.id}</p>
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            ) : (
+                <div className="text-center py-10">
+                    <p className="text-lg text-gray-300">You have no report history.</p>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,10 +1,11 @@
-import { getSSIDInfo, getCustomerInfo } from "./actions";
+import { getSSIDInfo, getCustomerInfo, getDashboardStatus } from "../actions";
 import ClientView from "./client.view";
 export const dynamic = 'force-dynamic'
 export default async function Page() {
-    const [ssidInfo, customerInfo] = await Promise.all([
+    const [ssidInfo, customerInfo, dashboardStatus] = await Promise.all([
         getSSIDInfo(),
-        getCustomerInfo()
+        getCustomerInfo(),
+        getDashboardStatus()
     ]);
 
     if (!ssidInfo) {
@@ -19,9 +20,5 @@ export default async function Page() {
         );
     }
 
-    return (
-        <div className="w-full min-h-[100dvh]">
-            <ClientView ssidInfo={ssidInfo} customerInfo={customerInfo}/>
-        </div>
-    );
+    return <ClientView ssidInfo={ssidInfo} customerInfo={customerInfo} dashboardStatus={dashboardStatus} />;
 }

--- a/src/app/dashboard/speed-boost/view.tsx
+++ b/src/app/dashboard/speed-boost/view.tsx
@@ -56,7 +56,7 @@ export default function SpeedBoostView({
     return (
         <div>
             {notification && (
-                <div className="toast toast-top toast-center z-[999]">
+                <div className="toast toast-bottom toast-center z-[999]">
                     <div className={`alert ${notification.success ? 'alert-success' : 'alert-error'}`}>
                         <span>{notification.message}</span>
                     </div>

--- a/src/app/dashboard/status.view.tsx
+++ b/src/app/dashboard/status.view.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import type { DashboardStatus } from "./actions";
+import { Hourglass, Zap } from 'lucide-react';
+
+export default function StatusView({ status }: { status: DashboardStatus }) {
+    return (
+        <div className="card bg-white/10 backdrop-blur-lg border border-white/20 shadow-xl col-span-1 md:col-span-2 xl:col-span-3">
+            <div className="card-body">
+                <h2 className="card-title text-white">Status Overview</h2>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-2">
+                    {/* Active Speed Boost */}
+                    <div className="p-4 bg-black/20 rounded-lg">
+                        <h3 className="font-semibold text-lg flex items-center gap-2"><Zap size={18}/> Active Speed Boost</h3>
+                        {status.activeBoost ? (
+                            <div className="mt-2 text-gray-300">
+                                <p>Your speed is currently boosted to <span className="font-bold text-primary">{status.activeBoost.profile}</span>.</p>
+                                <p className="text-sm">Expires on: {new Date(status.activeBoost.expiresAt).toLocaleString()}</p>
+                            </div>
+                        ) : (
+                            <p className="mt-2 text-gray-400">No active speed boost.</p>
+                        )}
+                    </div>
+
+                    {/* Active Report */}
+                    <div className="p-4 bg-black/20 rounded-lg">
+                        <h3 className="font-semibold text-lg flex items-center gap-2"><Hourglass size={18}/> Active Report</h3>
+                        {status.activeReport ? (
+                            <div className="mt-2 text-gray-300">
+                                <p>Report <span className="font-bold text-primary">#{status.activeReport.id}</span> ({status.activeReport.category}) is currently <span className="font-bold text-yellow-400">{status.activeReport.status}</span>.</p>
+                            </div>
+                        ) : (
+                            <p className="mt-2 text-gray-400">You have no active reports.</p>
+                        )}
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
This commit introduces several new features and a bug fix to enhance your dashboard experience.

**New Features:**

1.  **Dashboard Status Overview:**
    -   A new "Status Overview" card has been added to the main dashboard page.
    -   This card displays the status of any active Speed Boosts and any of your active reports, providing key information at a glance.
    -   A placeholder server action `getDashboardStatus` has been created to supply this data.

2.  **Report History Page:**
    -   A new "History" page has been created at `/dashboard/history`.
    -   A link has been added to the bottom navigation bar to access this page.
    -   The page displays a list of your past reports with their status (e.g., Submitted, In Progress, Resolved).
    -   A placeholder server action `getReportHistory` has been created to fetch this data.

**Bug Fixes:**

1.  **Mobile Notification Position:**
    -   The toast notification on the "Speed Boost" page has been moved from `toast-top` to `toast-bottom` to ensure it is visible on mobile devices and not obscured by other UI elements.