### PR TITLE
fix: Correct import path in client view

### DIFF
--- a/src/app/dashboard/client.view.tsx
+++ b/src/app/dashboard/client.view.tsx
@@ -8,7 +8,7 @@ import CustomerView from "./customer.view";
 import SignalStrengthIcon from "./SignalStrengthIcon";
 import StatusView from "./status.view";
 import { Power, RefreshCw, Check, X, Users } from 'lucide-react';
-import { DashboardStatus } from "../actions";
+import { DashboardStatus } from "./actions";
 
 export default function View({ ssidInfo: initialSsidInfo, customerInfo, dashboardStatus }: { ssidInfo: SSIDInfo, customerInfo: CustomerInfo | null, dashboardStatus: DashboardStatus }) {
     const [ssidInfo, setSSIDInfo] = useState<SSIDInfo>(initialSsidInfo);


### PR DESCRIPTION
This commit fixes a "Module not found" build error in the `client.view.tsx` component.

The error was caused by an incorrect relative import path for the `DashboardStatus` type. The path has been corrected from `../actions` to `./actions`.