### PR TITLE
fix: Remove unused imports from bottom navigation

### DIFF
--- a/src/app/dashboard/bottom.nav.tsx
+++ b/src/app/dashboard/bottom.nav.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { LayoutDashboard, Wifi, MessageSquareWarning, Rocket, History, Settings } from 'lucide-react';
+import { LayoutDashboard, Wifi, Rocket, Settings } from 'lucide-react';
 
 export default function BottomNav() {
     const pathname = usePathname();


### PR DESCRIPTION
This commit fixes an ESLint build error (`no-unused-vars`) in the `bottom.nav.tsx` component.

The `MessageSquareWarning` and `History` icons were being imported but were no longer used after a previous refactor. This commit removes them from the import statement to resolve the build failure.