### PR TITLE
fix: Resolve build error from conflicting export

### DIFF
--- a/src/app/dashboard/actions.ts
+++ b/src/app/dashboard/actions.ts
@@ -394,7 +394,6 @@ export type {
     AssociatedDevice,
     CustomerInfo,
     BoostPackage,
-    Package,
     ReportHistoryItem,
     DashboardStatus
 }


### PR DESCRIPTION
This commit fixes a build error caused by a duplicate export of the 'Package' type in `src/app/dashboard/actions.ts`.

The `Package` interface was already exported via `export interface`, making its inclusion in the `export type` block redundant and causing a name collision during the build process.

The redundant export has been removed to resolve the conflict.