### PR TITLE
feat: Implement username and password login

### DIFF
--- a/src/app/dashboard/actions.ts
+++ b/src/app/dashboard/actions.ts
@@ -1,7 +1,10 @@
 "use server";
 
+"use server";
+
 import { getAuthSession } from "@/lib/auth";
 import { revalidatePath } from "next/cache";
+import { updateCredentials } from "@/utils/auth.server";
 
 // Helper to get auth headers
 async function getAuthHeaders() {
@@ -387,7 +390,7 @@ export async function requestPackageChange(targetPackageName: string) {
     }
 }
 
-export { rebootRouter, refreshObject, getSSIDInfo, setPassword, setSSIDName, getCustomerInfo };
+export { rebootRouter, refreshObject, getSSIDInfo, setPassword, setSSIDName, getCustomerInfo, updateCredentials };
 export type {
     SSID,
     SSIDInfo,

--- a/src/utils/auth.server.ts
+++ b/src/utils/auth.server.ts
@@ -33,3 +33,69 @@ export const verify = async (phoneNumber: string, otp: string) => {
         token: json.token as string | undefined
     }
 }
+
+export const verifyPassword = async (username: string, password: string) => {
+    const req =  await fetch(`${process.env.API_URL}/api/customer/login`, {
+        method: 'POST',
+        body: JSON.stringify({
+            username,
+            password
+        }),
+        headers: {
+            'Content-Type': 'application/json'
+        }
+    })
+
+    if (req.status !== 200) {
+        return {
+            status: req.status,
+            user: null,
+            token: undefined
+        }
+    }
+
+    const json = await req.json();
+
+    return {
+        status: req.status,
+        user: json.user as { deviceId: string },
+        token: json.token as string | undefined
+    }
+}
+
+export const updateCredentials = async (currentPassword: string, newUsername?: string, newPassword?: string) => {
+    // We need to get the session to get the backend token
+    const { getAuthSession } = await import('@/lib/auth');
+    const session = await getAuthSession();
+
+    if (!session?.user?.backendToken) {
+        return {
+            status: 401,
+            message: "Not authenticated"
+        }
+    }
+
+    const body: { currentPassword: string; newUsername?: string; newPassword?: string } = { currentPassword };
+    if (newUsername) {
+        body.newUsername = newUsername;
+    }
+    if (newPassword) {
+        body.newPassword = newPassword;
+    }
+
+    const req = await fetch(`${process.env.API_URL}/api/customer/account/update`, {
+        method: 'POST',
+        body: JSON.stringify(body),
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${session.user.backendToken}`
+        }
+    });
+
+    const json = await req.json();
+
+    return {
+        status: req.status,
+        message: json.message
+    }
+}


### PR DESCRIPTION
Adds an alternative login method using username and password, complementing the existing OTP-based login.

- Modifies the login page with a tabbed interface to switch between OTP and username/password authentication.
- Extends NextAuth configuration with a new CredentialsProvider for handling username/password verification.
- Adds a new section to the settings page, allowing users to set or update their username and password after authenticating.
- Includes server-side actions to communicate with the backend API for login and credential updates, following the provided API documentation.