### PR TITLE
fix: Resolve ESLint build error

### DIFF
--- a/src/app/dashboard/settings/view.tsx
+++ b/src/app/dashboard/settings/view.tsx
@@ -69,6 +69,7 @@ export default function SettingsView({
                 setCredentialNotification({ message: result.message || 'Failed to update credentials.', success: false });
             }
         } catch (error) {
+            console.error("Failed to update credentials:", error);
             setCredentialNotification({ message: 'An unexpected error occurred.', success: false });
         } finally {
             setIsCredentialUpdateLoading(false);


### PR DESCRIPTION
Fixes an `no-unused-vars` ESLint error that was causing the production build to fail. The `error` variable in a try-catch block within `handleUpdateCredentials` was not being used.

The fix adds a `console.error` statement to log the caught error, which resolves the linting issue and improves debuggability.