### PR TITLE
fix: Restore OTP login functionality

### DIFF
--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -6,7 +6,7 @@ import 'react-phone-number-input/style.css'
 import PhoneInput from 'react-phone-number-input'
 import { Phone, KeyRound, User, Lock, ArrowRight } from 'lucide-react'; // Import icons
 
-type LoginMethod = 'otp' | 'credentials';
+type LoginMethod = 'otp' | 'username-password';
 
 export default function Login() {
     const [loginMethod, setLoginMethod] = useState<LoginMethod>('otp');
@@ -41,7 +41,7 @@ export default function Login() {
         e.preventDefault();
         setLoading(true);
         setAlertMessage('');
-        const result = await signIn('otp', {
+        const result = await signIn('credentials', {
             callbackUrl: '/dashboard',
             redirect: true,
             phoneNumber: phoneNumber!.slice(1),
@@ -58,7 +58,7 @@ export default function Login() {
         e.preventDefault();
         setLoading(true);
         setAlertMessage('');
-        const result = await signIn('credentials', {
+        const result = await signIn('username-password', {
             callbackUrl: '/dashboard',
             redirect: true,
             username,
@@ -179,7 +179,7 @@ export default function Login() {
                     <div className="card-body">
                         <div role="tablist" className="tabs tabs-boxed grid grid-cols-2 bg-black/20 mb-6">
                             <a role="tab" className={`tab ${loginMethod === 'otp' ? 'tab-active bg-primary' : ''}`} onClick={() => setLoginMethod('otp')}>Phone & OTP</a>
-                            <a role="tab" className={`tab ${loginMethod === 'credentials' ? 'tab-active bg-primary' : ''}`} onClick={() => setLoginMethod('credentials')}>Username</a>
+                            <a role="tab" className={`tab ${loginMethod === 'username-password' ? 'tab-active bg-primary' : ''}`} onClick={() => setLoginMethod('username-password')}>Username</a>
                         </div>
 
                         <h2 className="text-center text-3xl font-bold mb-2 text-white">

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -7,13 +7,14 @@ export const authOptions: NextAuthOptions = {
     // adapter: PrismaAdapter(prisma),
     providers: [
         CredentialsProvider({
-            id: 'otp',
+            id: 'credentials',
             name: 'OTP',
             credentials: {
               phoneNumber: {},
               otp: {},
             },
             async authorize(credentials) {
+                // This is the original provider, now with the default 'credentials' id
                 const r = await verify(credentials!.phoneNumber, credentials!.otp);
                 if (r.status === 200 && r.token) {
                     return {
@@ -26,8 +27,8 @@ export const authOptions: NextAuthOptions = {
             },
         }),
         CredentialsProvider({
-            id: 'credentials',
-            name: 'Credentials',
+            id: 'username-password',
+            name: 'Username & Password',
             credentials: {
                 username: {},
                 password: {}


### PR DESCRIPTION
Reverts the NextAuth provider ID for OTP login back to the default 'credentials' and assigns a new ID ('username-password') to the new username/password provider.

This fixes a bug where the OTP login flow was failing after the introduction of the second authentication provider. The original OTP login functionality is now restored.