### PR TITLE
Fix: Resolve login redirect loop

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -68,9 +68,6 @@ export const authOptions: NextAuthOptions = {
             session.user.deviceId = token.deviceId;
             session.user.backendToken = token.backendToken;
             return session;
-        },
-        redirect(){
-            return '/dashboard';
         }
     }
 }


### PR DESCRIPTION
Removes the custom `redirect` callback from the NextAuth.js options.

The hardcoded `redirect` callback was causing a race condition. It would redirect to the dashboard before the session was fully established, causing the middleware to redirect the user back to the login page, resulting in an infinite loop.

By removing the custom callback, NextAuth.js will use its default behavior, which correctly handles the post-login redirection after the session is established, honoring the `callbackUrl` provided during the `signIn` call.