### PR TITLE
Fix: Correct login API calls and resolve client-side error

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -47,22 +47,16 @@ export default function Login() {
         }
         setLoading(true);
         setAlertMessage('');
-        try {
-            const response = await requestOtp(phoneNumber);
-            if (response.ok) {
-                setOtpSent(true);
-                setAlertMessage('OTP has been sent to your WhatsApp.');
-            } else {
-                try {
-                    const body = await response.json();
-                    setAlertMessage(body.message || 'Failed to send OTP. Please try again.');
-                } catch {
-                    setAlertMessage('Failed to send OTP. Please check the number and try again.');
-                }
-            }
-        } catch {
-            setAlertMessage('An error occurred. Please try again.');
+
+        const response = await requestOtp(phoneNumber);
+
+        if (response.ok) {
+            setOtpSent(true);
+            setAlertMessage(response.message || 'OTP has been sent to your WhatsApp.');
+        } else {
+            setAlertMessage(response.message || 'Failed to send OTP. Please try again.');
         }
+
         setLoading(false);
     };
 

--- a/src/utils/auth.server.ts
+++ b/src/utils/auth.server.ts
@@ -1,20 +1,32 @@
 "use server"
 
 export const requestOtp = async (phoneNumber: string) => {
-    const req = await fetch(`${process.env.API_URL}/api/otp`, {
-        method: 'POST',
-        body: JSON.stringify({
-            phoneNumber
-        }),
-        headers: {
-            'Content-Type': 'application/json'
+    try {
+        const req = await fetch(`${process.env.API_URL}/api/auth/otp/request`, {
+            method: 'POST',
+            body: JSON.stringify({
+                phoneNumber
+            }),
+            headers: {
+                'Content-Type': 'application/json'
+            }
+        });
+
+        const data = await req.json();
+        return {
+            ok: req.ok,
+            message: data.message
+        };
+    } catch (error) {
+        return {
+            ok: false,
+            message: 'An unexpected error occurred.'
         }
-    })
-    return req;
+    }
 }
 
 export const verify = async (phoneNumber: string, otp: string) => {
-    const req =  await fetch(`${process.env.API_URL}/api/otpverify`, {
+    const req =  await fetch(`${process.env.API_URL}/api/auth/otp/verify`, {
         method: 'POST',
         body: JSON.stringify({
             phoneNumber,
@@ -35,7 +47,7 @@ export const verify = async (phoneNumber: string, otp: string) => {
 }
 
 export const verifyPassword = async (username: string, password: string) => {
-    const req =  await fetch(`${process.env.API_URL}/api/customer/login`, {
+    const req =  await fetch(`${process.env.API_URL}/api/auth/login`, {
         method: 'POST',
         body: JSON.stringify({
             username,


### PR DESCRIPTION
This commit addresses two critical issues in the authentication flow:

1.  **API Endpoint Mismatch:** The frontend was calling incorrect, non-existent API endpoints for username/password login, OTP request, and OTP verification. This commit updates the `fetch` calls in `src/utils/auth.server.ts` to use the correct endpoints (`/api/auth/login`, `/api/auth/otp/request`, `/api/auth/otp/verify`) as specified in the backend documentation. This was the root cause of the login failure.

2.  **Server Action Return Value:** The `requestOtp` server action was returning a raw `fetch` Response object to a client component, causing a Next.js error ("Only plain objects can be passed..."). The function has been refactored to return a simple, serializable JSON object (`{ ok, message }`). The corresponding client-side code in `src/app/(auth)/login/page.tsx` has been updated to handle this new return format.

This also includes a previous change to remove a hardcoded `redirect` callback from `src/lib/auth.ts` which was a likely contributor to the redirect loop.