### PR TITLE
Feat: Replace login alerts with toast notifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "next-auth": "^4.24.11",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-hot-toast": "^2.6.0",
     "react-phone-number-input": "^3.4.11",
     "recharts": "^3.1.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.0.0(react@19.0.0)
+      react-hot-toast:
+        specifier: ^2.6.0
+        version: 2.6.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react-phone-number-input:
         specifier: ^3.4.11
         version: 3.4.11(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -1057,6 +1060,11 @@ packages:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
 
+  goober@2.1.16:
+    resolution: {integrity: sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==}
+    peerDependencies:
+      csstype: ^3.0.10
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -1589,6 +1597,13 @@ packages:
     resolution: {integrity: sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==}
     peerDependencies:
       react: ^19.0.0
+
+  react-hot-toast@2.6.0:
+    resolution: {integrity: sha512-bH+2EBMZ4sdyou/DPrfgIouFpcRLCJ+HoCA32UoAYHn6T3Ur5yfcDCeSr5mwldl6pFOsiocmrXMuoCJ1vV8bWg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: '>=16'
+      react-dom: '>=16'
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -3109,6 +3124,10 @@ snapshots:
       define-properties: 1.2.1
       gopd: 1.2.0
 
+  goober@2.1.16(csstype@3.1.3):
+    dependencies:
+      csstype: 3.1.3
+
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
@@ -3617,6 +3636,13 @@ snapshots:
     dependencies:
       react: 19.0.0
       scheduler: 0.25.0
+
+  react-hot-toast@2.6.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+    dependencies:
+      csstype: 3.1.3
+      goober: 2.1.16(csstype@3.1.3)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
 
   react-is@16.13.1: {}
 

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import { signIn } from 'next-auth/react';
 import { User, Lock, ArrowRight, Smartphone, Key } from 'lucide-react';
 import { requestOtp } from '@/utils/auth.server';
+import toast from 'react-hot-toast';
 
 type LoginMethod = 'password' | 'otp';
 
@@ -20,13 +21,11 @@ export default function Login() {
     const [otpSent, setOtpSent] = useState(false);
 
     // Common state
-    const [alertMessage, setAlertMessage] = useState('');
     const [loading, setLoading] = useState(false);
 
     const handleCredentialsLogin = async (e: React.FormEvent) => {
         e.preventDefault();
         setLoading(true);
-        setAlertMessage('');
         const result = await signIn('username-password', {
             redirect: false,
             username,
@@ -37,26 +36,25 @@ export default function Login() {
         if (result?.ok) {
             window.location.href = '/dashboard';
         } else {
-            setAlertMessage(result?.error || 'An unknown error occurred.');
+            toast.error(result?.error || 'An unknown error occurred.');
         }
     };
 
     const handleRequestOtp = async (e: React.MouseEvent<HTMLButtonElement>) => {
         e.preventDefault();
         if (!/^\d{10,15}$/.test(phoneNumber)) {
-            setAlertMessage('Invalid phone number format.');
+            toast.error('Invalid phone number format.');
             return;
         }
         setLoading(true);
-        setAlertMessage('');
 
         const response = await requestOtp(phoneNumber);
 
         if (response.ok) {
             setOtpSent(true);
-            setAlertMessage(response.message || 'OTP has been sent to your WhatsApp.');
+            toast.success(response.message || 'OTP has been sent to your WhatsApp.');
         } else {
-            setAlertMessage(response.message || 'Failed to send OTP. Please try again.');
+            toast.error(response.message || 'Failed to send OTP. Please try again.');
         }
 
         setLoading(false);
@@ -65,7 +63,6 @@ export default function Login() {
     const handleWhatsAppLogin = async (e: React.FormEvent) => {
         e.preventDefault();
         setLoading(true);
-        setAlertMessage('');
         const result = await signIn('credentials', {
             redirect: false,
             phoneNumber,
@@ -76,7 +73,7 @@ export default function Login() {
         if (result?.ok) {
             window.location.href = '/dashboard';
         } else {
-            setAlertMessage(result?.error || 'An unknown error occurred.');
+            toast.error(result?.error || 'An unknown error occurred.');
         }
     };
 
@@ -189,7 +186,6 @@ export default function Login() {
         setPhoneNumber('');
         setOtp('');
         setOtpSent(false);
-        setAlertMessage('');
         setLoading(false);
     }
 
@@ -218,14 +214,6 @@ export default function Login() {
                         <p className="text-center text-sm text-gray-400 mb-6">
                             {loginMethod === 'password' ? 'Using your username and password' : 'Using your WhatsApp number'}
                         </p>
-
-
-                        {alertMessage && (
-                            <div role="alert" className={`alert ${otpSent && !alertMessage.includes("Invalid") && !alertMessage.includes("Failed") ? 'alert-success' : 'alert-error'} text-white bg-opacity-50 mb-4 border-none`}>
-                                <svg xmlns="http://www.w3.org/2000/svg" className="stroke-current shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
-                                <span>{alertMessage}</span>
-                            </div>
-                        )}
 
                         {loginMethod === 'password' ? renderCredentialsForm() : renderWhatsAppForm()}
                     </div>

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import { signIn } from 'next-auth/react';
 import { User, Lock, ArrowRight, Smartphone, Key } from 'lucide-react';
 import { requestOtp } from '@/utils/auth.server';
+import toast from 'react-hot-toast';
 
 type LoginMethod = 'password' | 'otp';
 
@@ -20,13 +21,11 @@ export default function Login() {
     const [otpSent, setOtpSent] = useState(false);
 
     // Common state
-    const [alertMessage, setAlertMessage] = useState('');
     const [loading, setLoading] = useState(false);
 
     const handleCredentialsLogin = async (e: React.FormEvent) => {
         e.preventDefault();
         setLoading(true);
-        setAlertMessage('');
         const result = await signIn('username-password', {
             redirect: false,
             username,
@@ -37,26 +36,25 @@ export default function Login() {
         if (result?.ok) {
             window.location.href = '/dashboard';
         } else {
-            setAlertMessage(result?.error || 'An unknown error occurred.');
+            toast.error(result?.error || 'An unknown error occurred.');
         }
     };
 
     const handleRequestOtp = async (e: React.MouseEvent<HTMLButtonElement>) => {
         e.preventDefault();
         if (!/^\d{10,15}$/.test(phoneNumber)) {
-            setAlertMessage('Invalid phone number format.');
+            toast.error('Invalid phone number format.');
             return;
         }
         setLoading(true);
-        setAlertMessage('');
 
         const response = await requestOtp(phoneNumber);
 
         if (response.ok) {
             setOtpSent(true);
-            setAlertMessage(response.message || 'OTP has been sent to your WhatsApp.');
+            toast.success(response.message || 'OTP has been sent to your WhatsApp.');
         } else {
-            setAlertMessage(response.message || 'Failed to send OTP. Please try again.');
+            toast.error(response.message || 'Failed to send OTP. Please try again.');
         }
 
         setLoading(false);
@@ -65,7 +63,6 @@ export default function Login() {
     const handleWhatsAppLogin = async (e: React.FormEvent) => {
         e.preventDefault();
         setLoading(true);
-        setAlertMessage('');
         const result = await signIn('credentials', {
             redirect: false,
             phoneNumber,
@@ -76,7 +73,7 @@ export default function Login() {
         if (result?.ok) {
             window.location.href = '/dashboard';
         } else {
-            setAlertMessage(result?.error || 'An unknown error occurred.');
+            toast.error(result?.error || 'An unknown error occurred.');
         }
     };
 
@@ -189,7 +186,6 @@ export default function Login() {
         setPhoneNumber('');
         setOtp('');
         setOtpSent(false);
-        setAlertMessage('');
         setLoading(false);
     }
 
@@ -218,14 +214,6 @@ export default function Login() {
                         <p className="text-center text-sm text-gray-400 mb-6">
                             {loginMethod === 'password' ? 'Using your username and password' : 'Using your WhatsApp number'}
                         </p>
-
-
-                        {alertMessage && (
-                            <div role="alert" className={`alert ${otpSent && !alertMessage.includes("Invalid") && !alertMessage.includes("Failed") ? 'alert-success' : 'alert-error'} text-white bg-opacity-50 mb-4 border-none`}>
-                                <svg xmlns="http://www.w3.org/2000/svg" className="stroke-current shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
-                                <span>{alertMessage}</span>
-                            </div>
-                        )}
 
                         {loginMethod === 'password' ? renderCredentialsForm() : renderWhatsAppForm()}
                     </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { Toaster } from "react-hot-toast";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -28,6 +29,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         {children}
+        <Toaster />
       </body>
     </html>
   );


### PR DESCRIPTION
This commit implements a new feature to enhance the user experience on the login pages. The previous text-based alert messages for success and error states have been replaced with modern, non-intrusive toast notifications using the `react-hot-toast` library.

The changes include:
- Added `react-hot-toast` as a project dependency.
- Integrated the global `<Toaster />` provider in the root layout to make notifications available application-wide.
- Refactored both login pages (`/app/(auth)/login/page.tsx` and `/app/auth/login/page.tsx`) to remove the old `alertMessage` state management.
- Replaced all `setAlertMessage` calls with `toast.success()` for successful actions (like OTP sent) and `toast.error()` for failures (like invalid credentials).

This change improves the visual feedback for the user during the authentication process.