### PR TITLE
Fix: Resolve login and package change issues

### DIFF
--- a/src/app/dashboard/settings/view.tsx
+++ b/src/app/dashboard/settings/view.tsx
@@ -41,8 +41,7 @@ export default function SettingsView({
     const [isPackageListOpen, setPackageListOpen] = useState(false);
     const [isPackageConfirmOpen, setPackageConfirmOpen] = useState(false);
 
-    const currentPrice = currentCustomerInfo.monthlyBill;
-    const availablePackages = allPackages.filter(p => parseFloat(p.price) > currentPrice);
+    const availablePackages = allPackages.filter(p => p.name !== currentCustomerInfo.packageName);
 
     const handleUpdateCredentials = async (e: React.FormEvent) => {
         e.preventDefault();

--- a/src/app/types/next-auth.d.ts
+++ b/src/app/types/next-auth.d.ts
@@ -12,6 +12,7 @@ declare module 'next-auth/jwt' {
     id: string;
     deviceId: string;
     backendToken: string;
+    userData: unknown;
   }
 }
 
@@ -24,6 +25,7 @@ declare module 'next-auth' {
     id: string;
     deviceId: string;
     backendToken: string;
+    userData: unknown;
   }
 
   /**
@@ -34,6 +36,7 @@ declare module 'next-auth' {
       id: string;
       deviceId: string;
       backendToken: string;
+      userData: unknown;
     };
   }
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -33,6 +33,7 @@ export const authOptions: NextAuthOptions = {
                     id: credentials.phoneNumber,
                     deviceId: r.user.deviceId,
                     backendToken: r.token,
+                    userData: r.user,
                 };
             },
         }),
@@ -58,11 +59,15 @@ export const authOptions: NextAuthOptions = {
                 if (!r.user) {
                     throw new Error("Authentication failed: User data not received from backend.");
                 }
+                if (!r.user.phoneNumber) {
+                    throw new Error("Authentication failed: User data from backend did not include a phone number.");
+                }
 
                 return {
-                    id: credentials.username,
+                    id: r.user.phoneNumber,
                     deviceId: r.user.deviceId,
                     backendToken: r.token,
+                    userData: r.user,
                 };
             }
         })
@@ -81,6 +86,7 @@ export const authOptions: NextAuthOptions = {
                 token.id = user.id;
                 token.deviceId = user.deviceId;
                 token.backendToken = user.backendToken;
+                token.userData = user.userData;
             }
             return token;
         },
@@ -88,6 +94,7 @@ export const authOptions: NextAuthOptions = {
             session.user.id = token.id;
             session.user.deviceId = token.deviceId;
             session.user.backendToken = token.backendToken;
+            session.user.userData = token.userData;
             return session;
         }
     }


### PR DESCRIPTION
This commit addresses two separate issues:

1.  **Login Data Display:** Customer data was not appearing after logging in with a username and password. This was because the session ID was being set to the username instead of the phone number, which is used for API lookups. The authentication logic has been updated to ensure the phone number from the backend response is always used as the session ID, regardless of the login method. The full user object from the backend is also now stored in the session for consistency.

2.  **Package Change Filtering:** The package change feature only showed more expensive packages (upgrades). The filtering logic has been modified to display all available packages except for the user's current one, allowing users to request both upgrades and downgrades.