### PR TITLE
feat: Refactor report form and add duplicate check

### DIFF
--- a/src/app/dashboard/report.form.tsx
+++ b/src/app/dashboard/report.form.tsx
@@ -1,65 +1,103 @@
 "use client";
 
-import { useFormState, useFormStatus } from 'react-dom';
+import { useState } from 'react';
 import { submitReport } from './actions';
-import { Send, LoaderCircle } from 'lucide-react';
-
-const initialState = {
-  message: '',
-  success: false,
-};
-
-function SubmitButton() {
-  const { pending } = useFormStatus();
-
-  return (
-    <button type="submit" className="btn bg-primary text-white border-none hover:bg-violet-700 w-full" aria-disabled={pending}>
-      {pending ? <LoaderCircle className="animate-spin" /> : <Send className="mr-2" />}
-      {pending ? 'Sending...' : 'Send Report'}
-    </button>
-  );
-}
+import { Send, LoaderCircle, MessageSquareWarning } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from '@/components/ui/dialog';
+import { toast } from 'sonner';
+import { Label } from '@/components/ui/label';
 
 export default function ReportForm() {
-  const [state, formAction] = useFormState(submitReport, initialState);
+    const [isLoading, setIsLoading] = useState(false);
+    const [isErrorDialogOpen, setErrorDialogOpen] = useState(false);
+    const [errorMessage, setErrorMessage] = useState('');
+    const [category, setCategory] = useState('');
+    const [description, setDescription] = useState('');
 
-  return (
-    <form action={formAction} className="space-y-4">
-      <div className="form-control">
-        <label htmlFor="category" className="label">
-          <span className="label-text text-gray-300">Issue Category</span>
-        </label>
-        <select
-          id="category"
-          name="category"
-          required
-          className="select select-bordered w-full text-white bg-black/20 focus:bg-black/30 focus:border-primary"
-        >
-          <option>Slow Connection</option>
-          <option>No Connection</option>
-          <option>Other</option>
-        </select>
-      </div>
-      <div className="form-control">
-        <label htmlFor="description" className="label">
-          <span className="label-text text-gray-300">Description</span>
-        </label>
-        <textarea
-          id="description"
-          name="description"
-          required
-          className="textarea textarea-bordered h-24 w-full text-white bg-black/20 focus:bg-black/30 focus:border-primary"
-          placeholder="Please describe the issue in detail."
-        ></textarea>
-      </div>
-      <div className="form-control mt-6">
-        <SubmitButton />
-      </div>
-      {state?.message && (
-        <p className={`mt-2 text-sm ${state.success ? 'text-green-400' : 'text-red-400'}`}>
-          {state.message}
-        </p>
-      )}
-    </form>
-  );
+    const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        if (!category || !description) {
+            toast.error("Please fill out all fields.");
+            return;
+        }
+
+        setIsLoading(true);
+        const formData = new FormData(e.currentTarget);
+
+        try {
+            const result = await submitReport(formData);
+
+            if (result.success) {
+                toast.success(result.message || "Report submitted successfully!");
+                setCategory('');
+                setDescription('');
+            } else {
+                setErrorMessage(result.message || "An unknown error occurred.");
+                setErrorDialogOpen(true);
+            }
+        } catch (error) {
+            setErrorMessage(error instanceof Error ? error.message : "An unexpected error occurred.");
+            setErrorDialogOpen(true);
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    return (
+        <>
+            <form onSubmit={handleSubmit} className="space-y-4">
+                <div className="space-y-2">
+                    <Label htmlFor="category">Issue Category</Label>
+                    <Select name="category" required onValueChange={setCategory} value={category}>
+                        <SelectTrigger id="category" className="w-full">
+                            <SelectValue placeholder="Select a category" />
+                        </SelectTrigger>
+                        <SelectContent>
+                            <SelectItem value="Slow Connection">Slow Connection</SelectItem>
+                            <SelectItem value="No Connection">No Connection</SelectItem>
+                            <SelectItem value="Other">Other</SelectItem>
+                        </SelectContent>
+                    </Select>
+                </div>
+                <div className="space-y-2">
+                    <Label htmlFor="description">Description</Label>
+                    <Textarea
+                        id="description"
+                        name="description"
+                        required
+                        placeholder="Please describe the issue in detail."
+                        className="resize-none"
+                        value={description}
+                        onChange={(e) => setDescription(e.target.value)}
+                    />
+                </div>
+                <div className="form-control mt-6">
+                    <Button type="submit" disabled={isLoading} className="w-full">
+                        {isLoading ? <LoaderCircle className="animate-spin mr-2" /> : <Send className="mr-2" />}
+                        {isLoading ? 'Sending...' : 'Send Report'}
+                    </Button>
+                </div>
+            </form>
+
+            <Dialog open={isErrorDialogOpen} onOpenChange={setErrorDialogOpen}>
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle className="text-red-500 flex items-center">
+                            <MessageSquareWarning className="mr-2" />
+                            Report Submission Failed
+                        </DialogTitle>
+                        <DialogDescription>
+                            {errorMessage}
+                        </DialogDescription>
+                    </DialogHeader>
+                    <DialogFooter>
+                        <Button variant="outline" onClick={() => setErrorDialogOpen(false)}>Close</Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+        </>
+    );
 }


### PR DESCRIPTION
This commit addresses two user requests for the report submission feature:

1.  **UI/UX Improvement:** The report form in `report.form.tsx` has been refactored to use `shadcn/ui` components (`<Select>`, `<Textarea>`, `<Button>`), making its design consistent with the rest of the application.

2.  **Error Handling for Duplicate Reports:** The `submitReport` action in `actions.ts` now checks if the user has an active report before allowing a new submission. If an active report exists, an error is returned. The `report.form.tsx` component has been updated to handle this error by displaying a prominent dialog popup to the user, similar to the package change feature. This prevents users from creating multiple reports.

The form was switched from using `useFormState` to a client-side `handleSubmit` function to better accommodate the dialog-based error handling.