### PR TITLE
fix: Resolve ESLint error in Textarea component

### DIFF
--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {


### PR DESCRIPTION
This commit fixes a build failure caused by an ESLint rule violation (`@typescript-eslint/no-empty-object-type`) in the `textarea.tsx` component.

The empty `TextareaProps` interface has been converted to a `type` alias. This change satisfies the linter without altering the component's functionality, allowing the project to build successfully.