### PR TITLE
fix: Atasi Error Build Kritis dengan Workaround Layout Sinkron

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -4,7 +4,10 @@ import "../globals.css";
 import { Toaster } from "react-hot-toast";
 import { ThemeProvider } from "@/components/theme-provider";
 import { NextIntlClientProvider } from "next-intl";
-import { getMessages } from "next-intl/server";
+
+// Direct import for messages as a workaround for the Next.js build issue
+import enMessages from "../../../messages/en.json";
+import idMessages from "../../../messages/id.json";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -21,16 +24,15 @@ export const metadata: Metadata = {
   description: "RAF CYBER NET Wifi Portal",
 };
 
-export default async function LocaleLayout({
+export default function LocaleLayout({
   children,
   params: { locale },
 }: {
   children: React.ReactNode;
   params: { locale: string };
 }) {
-  // Providing all messages to the client
-  // side is a good default.
-  const messages = await getMessages();
+  // Select messages based on locale
+  const messages = locale === "id" ? idMessages : enMessages;
 
   return (
     <html lang={locale} suppressHydrationWarning>


### PR DESCRIPTION
Komit ini secara spesifik memperbaiki error build `LayoutProps` yang persisten dengan menerapkan sebuah workaround untuk menghindari kemungkinan bug pada type-checker Next.js v15.5.2.

- **Perubahan Kunci:**
  - Mengubah `[locale]/layout.tsx` dari komponen `async` menjadi komponen sinkron.
  - Menghapus penggunaan `await getMessages()` dari `next-intl` di dalam layout.
  - Menggantinya dengan mengimpor file terjemahan JSON (`en.json`, `id.json`) secara langsung dan memilihnya berdasarkan `locale`.

- **Alasan:**
  - Perubahan ini secara efektif menghindari pemicu bug pada type-checker Next.js yang tampaknya tidak dapat menangani layout `async` dengan benar dalam konteks ini, sehingga menyelesaikan masalah build.

- **Fitur Sebelumnya:**
  - Semua fungsionalitas yang telah diimplementasikan sebelumnya (i18n, contoh API, restrukturisasi rute) tetap utuh dan berfungsi dengan workaround ini.