### PR TITLE
fix: Resolve TypeScript error during i18n build

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,10 @@
 import type { NextConfig } from "next";
+import withNextIntl from "next-intl/plugin";
+
+const withIntl = withNextIntl("./src/i18n.ts");
 
 const nextConfig: NextConfig = {
   /* config options here */
 };
 
-export default nextConfig;
+export default withIntl(nextConfig);

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -24,6 +24,10 @@ export const metadata: Metadata = {
   description: "RAF CYBER NET Wifi Portal",
 };
 
+export function generateStaticParams() {
+  return [{ locale: "en" }, { locale: "id" }];
+}
+
 export default function LocaleLayout({
   children,
   params: { locale },


### PR DESCRIPTION
The build process was failing with a TypeScript error related to 'LayoutProps' and an incompatible 'params' type.

This was caused by two issues:
1. The 'next.config.ts' was not configured with the 'withNextIntl' plugin, which is required for the Next.js build process to handle i18n routing correctly.
2. The root layout for the locales at 'src/app/[locale]/layout.tsx' was missing the 'generateStaticParams' function. This function is necessary to inform Next.js of the available locales for static generation, which resolves type inference issues at build time.

This commit addresses both issues by correctly configuring 'next.config.ts' and adding 'generateStaticParams' to the layout file.