### PR TITLE
fix: Resolve i18n build error with correct server-side handling

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -4,10 +4,7 @@ import "../globals.css";
 import { Toaster } from "react-hot-toast";
 import { ThemeProvider } from "@/components/theme-provider";
 import { NextIntlClientProvider } from "next-intl";
-
-// Direct import for messages as a workaround for the Next.js build issue
-import enMessages from "../../../messages/en.json";
-import idMessages from "../../../messages/id.json";
+import { getMessages, unstable_setRequestLocale } from "next-intl/server";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -28,15 +25,15 @@ export function generateStaticParams() {
   return [{ locale: "en" }, { locale: "id" }];
 }
 
-export default function LocaleLayout({
+export default async function LocaleLayout({
   children,
   params: { locale },
 }: {
   children: React.ReactNode;
   params: { locale: string };
 }) {
-  // Select messages based on locale
-  const messages = locale === "id" ? idMessages : enMessages;
+  unstable_setRequestLocale(locale);
+  const messages = await getMessages();
 
   return (
     <html lang={locale} suppressHydrationWarning>


### PR DESCRIPTION
Refactors the root locale layout to correctly handle server-side internationalization with 'next-intl'.

The previous attempt failed because the layout component was not correctly configured for server-side rendering with static params.

This commit resolves the issue by:
1. Making the layout component 'async'.
2. Calling 'unstable_setRequestLocale(locale)' to inform Next.js of the rendering context.
3. Using 'await getMessages()' to load translations instead of direct JSON imports.

This aligns the implementation with 'next-intl' best practices for the App Router and resolves the persistent build error.