### PR TITLE
feat: Replace associated devices chart with a table

### DIFF
--- a/src/app/dashboard/associated-devices-table.tsx
+++ b/src/app/dashboard/associated-devices-table.tsx
@@ -33,7 +33,7 @@ export default function AssociatedDevicesTable({ devices }: AssociatedDevicesTab
                 {devices.map((device, index) => (
                     <TableRow key={device.mac || index}>
                         <TableCell className="font-medium">{device.hostName || "Unknown Device"}</TableCell>
-                        <TableCell>{device.ipAddress || "N/A"}</TableCell>
+                        <TableCell>{device.ip || "N/A"}</TableCell>
                         <TableCell className="text-right">
                             <div className="flex items-center justify-end gap-2">
                                 <span>{device.signal || "N/A"}</span>


### PR DESCRIPTION
- Replaced the `AssociatedDevicesChart` component with a new `AssociatedDevicesTable` component.
- The new table displays the device name, IP address, and signal strength for each associated device.
- The signal strength is also represented by a Wi-Fi icon.
- fix: remove unused import
- fix: use correct ip property in table