### PR TITLE
feat: Perbaiki API untuk nama perusahaan, pengumuman, dan berita

### DIFF
--- a/src/app/api/announcements/route.ts
+++ b/src/app/api/announcements/route.ts
@@ -2,15 +2,24 @@ import { NextResponse } from "next/server";
 
 // PENTING: Ini adalah penyimpanan di memori. Data akan hilang saat server dimulai ulang.
 // Ganti ini dengan database sungguhan di lingkungan produksi.
-const announcements: { id: string; message: string; createdAt: Date }[] = [
-    {
-        id: "1",
-        message: "Selamat datang di portal WiFi kami! Nikmati koneksi yang stabil dan cepat.",
-        createdAt: new Date()
-    }
+const announcementsData = [
+  {
+    "id": "1672531200000",
+    "message": "Selamat Tahun Baru 2025! Semoga di tahun yang baru ini kita semua diberikan kesehatan dan kesuksesan.",
+    "createdAt": "2025-01-01T00:00:00.000Z"
+  },
+  {
+    "id": "1672444800000",
+    "message": "Akan ada maintenance jaringan pada tanggal 31 Desember 2024 pukul 23:00.",
+    "createdAt": "2024-12-31T00:00:00.000Z"
+  }
 ];
 
 export async function GET() {
   // Di aplikasi sungguhan, Anda akan mengambil data ini dari database
-  return NextResponse.json(announcements);
+  // dan memastikan data diurutkan dari yang terbaru ke yang terlama.
+  const sortedAnnouncements = announcementsData.sort((a, b) =>
+    new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+  );
+  return NextResponse.json(sortedAnnouncements);
 }

--- a/src/app/api/news/route.ts
+++ b/src/app/api/news/route.ts
@@ -2,16 +2,26 @@ import { NextResponse } from "next/server";
 
 // PENTING: Ini adalah penyimpanan di memori. Data akan hilang saat server dimulai ulang.
 // Ganti ini dengan database sungguhan di lingkungan produksi.
-const newsItems: { id: string; title: string; content: string; createdAt: Date }[] = [
-    {
-        id: "1",
-        title: "Promo Spesial Bulan Ini!",
-        content: "Dapatkan diskon 20% untuk perpanjangan paket internet Anda bulan ini. Hubungi kami untuk info lebih lanjut.",
-        createdAt: new Date()
-    }
+const newsData = [
+  {
+    "id": "news_1672531200000",
+    "title": "Promo Spesial Tahun Baru!",
+    "content": "Dapatkan diskon 50% untuk pendaftaran baru selama bulan Januari 2025.",
+    "createdAt": "2025-01-01T00:00:00.000Z"
+  },
+  {
+    "id": "news_1672444800000",
+    "title": "Peningkatan Kecepatan Gratis!",
+    "content": "Nikmati peningkatan kecepatan gratis selama bulan Desember 2024.",
+    "createdAt": "2024-12-31T00:00:00.000Z"
+  }
 ];
 
 export async function GET() {
   // Di aplikasi sungguhan, Anda akan mengambil data ini dari database
-  return NextResponse.json(newsItems);
+  // dan memastikan data diurutkan dari yang terbaru ke yang terlama.
+  const sortedNews = newsData.sort((a, b) =>
+    new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+  );
+  return NextResponse.json(sortedNews);
 }

--- a/src/app/api/wifi-name/route.ts
+++ b/src/app/api/wifi-name/route.ts
@@ -1,0 +1,6 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  const wifiName = "RAF NET";
+  return NextResponse.json({ wifiName });
+}

--- a/src/app/dashboard/actions.ts
+++ b/src/app/dashboard/actions.ts
@@ -399,6 +399,24 @@ export async function requestPackageChange(targetPackageName: string) {
     }
 }
 
+export async function getCompanyName(): Promise<string> {
+    try {
+        // This function can be called from server components/pages.
+        const res = await fetch(`${process.env.API_URL}/api/wifi-name`, {
+            cache: 'force-cache' // Cache the result as it's not expected to change often
+        });
+        if (!res.ok) {
+            console.error(`Error fetching company name: ${res.status} ${res.statusText}`);
+            return "Default WiFi Portal"; // Fallback name
+        }
+        const data = await res.json();
+        return data.wifiName;
+    } catch (error) {
+        console.error("Failed to fetch company name:", error);
+        return "Default WiFi Portal"; // Fallback name
+    }
+}
+
 export { rebootRouter, refreshObject, getSSIDInfo, setPassword, setSSIDName, getCustomerInfo, updateCredentials };
 export type {
     SSID,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { Toaster } from "react-hot-toast";
 import { ThemeProvider } from "@/components/theme-provider";
+import { getCompanyName } from "./dashboard/actions";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -14,10 +15,13 @@ const geistMono = Geist_Mono({
   subsets: ["latin"],
 });
 
-export const metadata: Metadata = {
-  title: "RAF CYBER NET",
-  description: "RAF CYBER NET Wifi Portal",
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const companyName = await getCompanyName();
+  return {
+    title: companyName,
+    description: `${companyName} Wifi Portal`,
+  };
+}
 
 export default function RootLayout({
   children,


### PR DESCRIPTION
Menambahkan dan memperbarui endpoint API untuk menyelaraskan dengan spesifikasi backend yang baru.

- Membuat endpoint baru `GET /api/wifi-name` untuk mengambil nama perusahaan.
- Memperbarui layout utama untuk mengambil nama perusahaan secara dinamis dan menggunakannya sebagai judul halaman.
- Memperbaiki format data dan menambahkan pengurutan untuk endpoint `GET /api/announcements`.
- Memperbaiki format data dan menambahkan pengurutan untuk endpoint `GET /api/news`.

Perubahan ini memastikan bahwa frontend menggunakan logika API yang benar untuk menampilkan nama perusahaan, pengumuman, dan berita.