### PR TITLE
fix: Add environment variable checks to fix unresponsive login

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -2,6 +2,10 @@ import type { NextAuthOptions } from 'next-auth';
 import { getServerSession } from 'next-auth';
 import CredentialsProvider from 'next-auth/providers/credentials';
 import { verify, verifyPassword } from '@/utils/auth.server';
+
+if (!process.env.NEXTAUTH_SECRET) {
+    throw new Error('FATAL: NEXTAUTH_SECRET environment variable is not set.');
+}
   
 export const authOptions: NextAuthOptions = {
     // adapter: PrismaAdapter(prisma),

--- a/src/utils/auth.server.ts
+++ b/src/utils/auth.server.ts
@@ -1,6 +1,13 @@
 "use server"
 
 export const requestOtp = async (phoneNumber: string) => {
+    if (!process.env.API_URL) {
+        console.error("FATAL: API_URL environment variable is not set.");
+        return {
+            ok: false,
+            message: 'Server configuration error: API_URL is not set.'
+        }
+    }
     try {
         const req = await fetch(`${process.env.API_URL}/api/auth/otp/request`, {
             method: 'POST',
@@ -50,6 +57,14 @@ export const verify = async (phoneNumber: string, otp: string) => {
 }
 
 export const verifyPassword = async (username: string, password: string) => {
+    if (!process.env.API_URL) {
+        console.error("FATAL: API_URL environment variable is not set.");
+        return {
+            status: 500,
+            user: null,
+            token: undefined
+        };
+    }
     try {
         const req = await fetch(`${process.env.API_URL}/api/auth/login`, {
             method: 'POST',


### PR DESCRIPTION
The login and OTP buttons were unresponsive due to missing server-side environment variables (`API_URL`, `NEXTAUTH_SECRET`) that caused the Server Action mechanism to fail silently.

This commit adds checks to provide clear feedback and fail gracefully.

- In `src/utils/auth.server.ts`, the `requestOtp` and `verifyPassword` functions now check for `API_URL` and return a clear error message if it's not set. This allows the frontend to display a helpful error toast.

- In `src/lib/auth.ts`, a check is added to ensure `NEXTAUTH_SECRET` is defined. If it's missing, the application will throw an error on startup, preventing it from running in a broken state.