### PR TITLE
refactor: Refactor API routes to proxy to the real backend

### DIFF
--- a/src/app/api/wifi-name/route.ts
+++ b/src/app/api/wifi-name/route.ts
@@ -1,6 +1,34 @@
 import { NextResponse } from "next/server";
 
 export async function GET() {
-  const wifiName = "RAF NET";
-  return NextResponse.json({ wifiName });
+  if (!process.env.API_URL) {
+    return NextResponse.json(
+      { message: "Server configuration error: API_URL is not set." },
+      { status: 500 }
+    );
+  }
+
+  try {
+    const backendResponse = await fetch(`${process.env.API_URL}/api/wifi-name`, {
+      next: { revalidate: 3600 } // Cache for 1 hour, as this likely doesn't change often
+    });
+
+    if (!backendResponse.ok) {
+      const errorData = await backendResponse.json().catch(() => ({}));
+      return NextResponse.json(
+        { message: "Failed to fetch wifi name from backend.", details: errorData },
+        { status: backendResponse.status }
+      );
+    }
+
+    const data = await backendResponse.json();
+    return NextResponse.json(data);
+
+  } catch (error) {
+    console.error("Error fetching wifi name:", error);
+    return NextResponse.json(
+      { message: "An internal server error occurred." },
+      { status: 500 }
+    );
+  }
 }


### PR DESCRIPTION
The API routes for announcements, news, and wifi-name were previously returning hardcoded mock data, causing a discrepancy with the actual backend.

This commit refactors these three API routes to act as proxies. They now fetch data dynamically from the corresponding endpoints on the backend defined by the `API_URL` environment variable.

Caching has also been added to these routes to improve performance. This change ensures the data displayed to the user is always in sync with the real backend.