### PR TITLE
fix: Remove unused imports to resolve build error

### DIFF
--- a/src/app/dashboard/report.form.tsx
+++ b/src/app/dashboard/report.form.tsx
@@ -2,11 +2,10 @@
 
 import { useState } from 'react';
 import { submitReport } from './actions';
-import { Send, LoaderCircle, MessageSquareWarning } from 'lucide-react';
+import { Send, LoaderCircle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from '@/components/ui/dialog';
 import { Card, CardContent, CardFooter } from '@/components/ui/card';
 import { toast } from 'sonner';
 import { Label } from '@/components/ui/label';


### PR DESCRIPTION
The build was failing due to an ESLint error (`@typescript-eslint/no-unused-vars`). This was caused by leftover imports in `src/app/dashboard/report.form.tsx` after a recent refactoring of the notification system.

This commit removes the unused imports for `Dialog` components and `MessageSquareWarning`, which resolves the build failure and cleans up the component.