### PR TITLE
fix: Display dynamic company name in page header

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -21,10 +21,10 @@ export default function DashboardLayout({
   const [companyName, setCompanyName] = useState("Memuat...");
 
   useEffect(() => {
-    fetch('/api/settings')
+    fetch('/api/wifi-name')
       .then(res => res.json())
       .then(data => {
-        setCompanyName(data.companyName);
+        setCompanyName(data.wifiName);
       });
   }, []);
 
@@ -50,10 +50,10 @@ export default function DashboardLayout({
       <DialogContent>
           <DialogHeader>
               <DialogTitle className="flex items-center">
-                  <MessageSquareWarning className="mr-2"/>Report an Issue
+                  <MessageSquareWarning className="mr-2"/>Laporkan Masalah
               </DialogTitle>
               <DialogDescription>
-                  Please fill out the form below to report an issue with your connection.
+                  Mohon isi formulir di bawah ini untuk melaporkan masalah terkait koneksi Anda.
               </DialogDescription>
           </DialogHeader>
           <div className="py-4">


### PR DESCRIPTION
The dashboard header was not displaying the company name fetched from the API, although the page title (favicon text) was correct.

This was because the `dashboard/layout.tsx` component was using a `useEffect` hook to fetch from an incorrect endpoint (`/api/settings`).

This commit corrects the `fetch` call in the `useEffect` hook to point to the correct `/api/wifi-name` endpoint and parse the correct `wifiName` field from the response. This ensures the visible page header is in sync with the API.

A minor translation fix for the "Report an Issue" dialog title within the same layout file is also included.