### PR TITLE
feat: Fetch allowed SSIDs from customer profile

### DIFF
--- a/src/app/dashboard/wifi/page.tsx
+++ b/src/app/dashboard/wifi/page.tsx
@@ -1,4 +1,4 @@
-import { getSSIDInfo } from "../actions";
+import { getSSIDInfo, getCustomerInfo } from "../actions";
 import WifiView from "./view";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Terminal } from "lucide-react";
@@ -6,7 +6,14 @@ import { Terminal } from "lucide-react";
 export const dynamic = 'force-dynamic';
 
 export default async function WifiPage() {
-    const ssidInfo = await getSSIDInfo();
+    const customerInfo = await getCustomerInfo();
+
+    // Determine the list of allowed SSIDs. Use customer's config if available, otherwise default to ["1"].
+    const allowedSsids = customerInfo?.allowed_ssids && customerInfo.allowed_ssids.length > 0
+        ? customerInfo.allowed_ssids
+        : ["1"];
+
+    const ssidInfo = await getSSIDInfo(allowedSsids);
 
     if (!ssidInfo) {
         return (

--- a/src/app/dashboard/wifi/view.tsx
+++ b/src/app/dashboard/wifi/view.tsx
@@ -15,19 +15,28 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 
-const allowSsid = ["1", "5"];
-
 export default function WifiView({ ssidInfo: initialSsidInfo }: { ssidInfo: SSIDInfo }) {
     const [ssidInfo] = useState<SSIDInfo>(initialSsidInfo);
-    const [selectedSSID, setSelectedSSID] = useState<string>(ssidInfo.ssid[0].id);
-    const [syncedSsids, setSyncedSsids] = useState<string[]>(allowSsid);
+
+    // Initialize selectedSSID to "1" if available, otherwise to the first SSID.
+    const [selectedSSID, setSelectedSSID] = useState<string>(() => {
+        const availableSsids = ssidInfo.ssid;
+        if (availableSsids.some(s => s.id === "1")) {
+            return "1";
+        }
+        return availableSsids.length > 0 ? availableSsids[0].id : "";
+    });
+
+    // Initialize with no SSIDs synced, so the switch is off by default.
+    const [syncedSsids, setSyncedSsids] = useState<string[]>([]);
 
     const refreshSsidInfo = () => {
         window.location.reload();
     };
 
     const handleSyncChange = (checked: boolean) => {
-        setSyncedSsids(checked ? allowSsid : []);
+        // When toggling, use the list of all available SSIDs from props.
+        setSyncedSsids(checked ? ssidInfo.ssid.map(s => s.id) : []);
     };
 
     return (


### PR DESCRIPTION
Replaced the hardcoded list of allowed SSIDs with a dynamic fetch from the customer's profile, integrating the logic into the existing data flow.

- Updated the `CustomerInfo` interface to include an optional `allowed_ssids` array.
- Modified `getSSIDInfo` to be parameterized, accepting a list of allowed SSIDs to filter against.
- Secured `setPassword` and `setSSIDName` by having them fetch the customer profile internally to get the authoritative list of allowed SSIDs for validation.
- Reworked the `wifi/page.tsx` component to orchestrate the data fetching: it now gets the customer profile first, determines the allowed SSIDs (defaulting to `["1"]`), and then fetches the filtered SSID information.
- Updated the `wifi/view.tsx` component to correctly handle the initial UI state, defaulting to a single selected SSID and the 'Sync' switch being off.